### PR TITLE
works under Python 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,37 @@
 # LuIsabel
+
 Plotting tool based on the arduino plotter using python and Qt, with extended functionality.
 
 Here a little Demo:
 ![Luisabel small Demo](https://github.com/raquenaengineering/arduino_plotter_pyqt/blob/main/docu/readme_images/luisabel_demo.gif)
 
+## Dependencies
 
-
-## Dependencies 
-
++ Python 3.9(!)
 + Pyserial:
-pip install pyserial
+  pip install pyserial
 + PyQt5:
-pip install PyQt5
+  pip install PyQt5
 + numpy:
-pip install numpy
+  pip install numpy
 + pyqtgraph:
-pip install pyqtgraph
+  pip install pyqtgraph
 + Qt Widgets:
-pip install qtwidgets
-
+  pip install qtwidgets
 + To simplify (in the project folder):
-pip install -r requirements.txt
-
+  pip install -r requirements.txt
 + submodules:
-git submodule update --init --recursive
-
+  git submodule update --init --recursive
 
 ## Many thanks to:
+
 + Qt Development team:
-Is such a great tool!
+  Is such a great tool!
 + Developers who ported QT5 to python :
-Even better when it's so easy to develop!
+  Even better when it's so easy to develop!
 + [PyqtGraph Developers](https://github.com/pyqtgraph/pyqtgraph):
-This tool wouldn't have been possible without his fantastic pyqtgraph library.
+  This tool wouldn't have been possible without his fantastic pyqtgraph library.
 + [Martin Fitzpatrick](https://github.com/mfitzp):
-For writing qtwidgets, and also for his book about PyQt5.
+  For writing qtwidgets, and also for his book about PyQt5.
 + [Yusuke Kamiyamane](https://p.yusukekamiyamane.com/):
-For the icons.
+  For the icons.

--- a/main_window.py
+++ b/main_window.py
@@ -285,7 +285,7 @@ class MainWindow(QMainWindow):
 		self.combo_serial_speed = QComboBox()
 		self.combo_serial_speed.setEditable(False)						# by default it isn't editable, but just in case.
 		self.combo_serial_speed.addItems(SERIAL_SPEEDS)
-		self.combo_serial_speed.setCurrentIndex(11)						# this index corresponds to 250000 as default baudrate.
+		self.combo_serial_speed.setCurrentIndex(SERIAL_SPEEDS.index(str(self.serial_baudrate)))						# this index corresponds to 250000 as default baudrate.
 		self.combo_serial_speed.currentTextChanged.connect(				# on change on the serial speed textbox, we call the connected mthod
 			self.change_serial_speed) 									# we'll figure out which is the serial speed at the method (would be possible to use a lambda?) 
 		self.layoutH1.addWidget(self.combo_serial_speed)				# 
@@ -463,6 +463,7 @@ class MainWindow(QMainWindow):
 		self.record_timer.start()
 		self.plot_frame.dataset = self.dataset
 		self.status_bar.showMessage("Connecting...")					# showing sth is happening. 
+		self.plot_frame.enable_toggles("all")
 		self.start_serial()
 		self.setup_slave()												# depending on the choosen mode, there are some requirements to start getting data.
 		self.on_button_play()
@@ -796,17 +797,17 @@ class MainWindow(QMainWindow):
 			# 		self.plot_frame.set_channels_labels(text_vals)		# this sets all labels, I need to set them independently !!!
 			# 	else:
 			# 		self.add_values_to_dataset(valsf)
-
-			try:
-				for val in vals:
+			text_vals = []
+			for val in vals:
+				try:
 					valsf.append(float(val))
-			except:
-				logging.debug("It contains also text");
-				# add to a captions vector
-				text_vals = vals
-				self.plot_frame.set_channels_labels(text_vals)
-			else:
-				self.add_values_to_dataset(valsf)
+				except:
+					# logging.debug("It contains also text")
+					# add to a captions vector
+					text_vals.append(val)
+					self.plot_frame.set_channels_labels(text_vals)
+				else:
+					self.add_values_to_dataset(valsf)
 
 			self.plot_frame.update()
 			#print("dataset_changed = "+ str(self.plot_frame.graph.dataset_changed))


### PR DESCRIPTION
Fixed the bug mentioned in #3 (toggles disabled).
Fixed a bug I was having w/ bad parsing of labeled Arduino styled data - changed `arduino_parse` lines 799-810:
```cpp
	text_vals = []
	for val in vals:
		try:
			valsf.append(float(val))
		except:
			# logging.debug("It contains also text")
			# add to a captions vector
			text_vals.append(val)
			self.plot_frame.set_channels_labels(text_vals)
		else:
			self.add_values_to_dataset(valsf)
```
Tied initial value in baud rate button to actual rate.

Works under Windows 10/11, Python 3.9.
